### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# Use latest Maven as base docker image
+FROM maven
+
+# define mainworkdir
+WORKDIR /opt/application
+
+# add all app files to workdir
+ADD . /opt/application
+
+# install & package
+RUN mvn install
+RUN mvn package
+
+# expose port 8080
+EXPOSE 8080
+
+# define run command
+CMD ["mvn", "jetty:run"]


### PR DESCRIPTION
This PR adds a simple Dockerfile, but that won't simplify the deployment much.
Mostly due to the way the app handles configuration. Ideally you would want to allow passing config options through ENV variables. This would allow two things:
1. Creating docker-compose.yml file that'll start nanopub-server _and_ mongodb together, so that starting nanopub literally becomes `docker-compose up`
2. Configuring autobuild on https://hub.docker.com/ so that users can simply pull working image, pass config through run command without need to build it themselves.
If you are interested in pursuing this - let me know, I can help you with that.
