### PR TITLE
Add docker-compose file, use env config and allow one-command deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ RUN mvn package
 EXPOSE 8080
 
 # define run command
-CMD ["mvn", "jetty:run"]
+CMD ["bash", "scripts/start.sh"]

--- a/README.md
+++ b/README.md
@@ -8,6 +8,21 @@ entire nanopubs. No queries supported; no triple store involved. The current
 implementation uses MongoDB to store the nanopubs.
 
 
+Easy Deployment with Docker
+--------------------------
+
+Requirements:
+
+- Docker 1.10 or higher
+- Docker-compose 1.6 or higher
+
+After cloning the repository and simply execute:
+
+    $ docker-compose up
+
+Config can be changed by passing environment variables prefixed with `NPS_`.
+E.g. setting `mongodb.host` is done via variable `NPS_MONGODB_HOST`.
+
 Compilation and Deployment
 --------------------------
 
@@ -57,7 +72,6 @@ server to map a public URL to the nanopub server, for example:
 
 Add the public URL to the line `public-url=` of the configuration file and
 recompile and restart the server. Then, it will connect to the server network.
-
 
 Usage
 -----

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '2'
+services:
+  nanopub:
+    build: .
+    depends_on:
+      - db
+    environment:
+      - NPS_MONGODB_HOST=db
+    ports:
+      - 8080:8080
+  db:
+    image: mongo


### PR DESCRIPTION
So, I'd added docker-compose file for one-command deployment, it seems to work just fine.
I had to adjust start.sh script to autocopy config if it doesn't exist, but that's the only change I made to non-docker files.
I also added a short howto to readme.
