### PR TITLE
Removed target directory from .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 /.*
-/target
 /bin
 /scratch
 /load


### PR DESCRIPTION
The docker image is built by first running mvn install locally and then copying the result to the docker container.
Because the target/ directory was in .dockerignore, docker wasn't able to find it and the image could not be built, so this entry has been removed from .dockerignore